### PR TITLE
add docker credential on frozen vm

### DIFF
--- a/Advanced-user-guide.md
+++ b/Advanced-user-guide.md
@@ -36,6 +36,38 @@ If you would like this script to support another Linux distro, you should create
 
 Below are some common configurations which you may want to modify:
 
+### Add docker credential
+Edit the following fields of `config/vsphere.pkrvars.hcl` file to add docker crendential.
+```hcl
+common_ray_docker_image = "rayproject/ray:latest"
+common_ray_docker_repo = "docker.io"
+common_ray_docker_username = "<your-docker-username>"
+common_ray_docker_password = "<your-docker-password>"
+```
+
+### Create frozen vms for each host
+
+Create frozen vms for each host by the following command with argument `--enable-frozenvm-each-host` :
+```
+bash create-frozen-vm.sh --enable-frozenvm-each-host
+```
+and the following configuration:
+
+```hcl
+frozen_vm_pool_name     = "<frozen-vm-pool-name>"
+frozen_vm_prefix_name   = "<frozen_vm_prefix_name>"
+```
+
+Then, all frozen vms are created under resource pool `<frozen-vm-pool-name>`, with name `<frozen_vm_prefix_name>-1`,  `<frozen_vm_prefix_name>-2`... and `<frozen_vm_prefix_name>-n`
+
+### Specify frozen vm name
+Create frozen vm by the following configuration:
+```hcl
+frozen_vm_prefix_name   = "<frozen_vm_prefix_name>"
+```
+
+Then, the frozen vm is created with name `<frozen_vm_prefix_name>-1`.
+
 ### Change the password of user "ray"
 
 The default username for the Ray nodes would be "ray", we recommend you to DO NOT change that.

--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -44,7 +44,17 @@
     sudo /usr/bin/dpkg -i --force-all /tmp/vmware-gosc_12.1.0.25580-20029049_amd64.deb >> ./dpkg.log 2>&1
 - name: "Pulling latest docker image from {{RAY_DOCKER_IMAGE}}"
   shell: |
-    sudo systemctl daemon-reload && sudo systemctl restart docker && sudo docker pull {{RAY_DOCKER_IMAGE}}
+    sudo tee /tmp/pull.sh << EOF
+    #!/bin/bash
+    sudo systemctl daemon-reload  || exit
+    sudo systemctl restart docker || exit
+    if [[ ! -z "{{RAY_DOCKER_USERNAME}}" && ! -z "{{RAY_DOCKER_PASSWORD}}" ]]; then
+        sudo docker login {{RAY_DOCKER_REPO}}  -u {{RAY_DOCKER_USERNAME}} -p {{RAY_DOCKER_PASSWORD}} || exit
+    fi
+    sudo docker pull {{RAY_DOCKER_IMAGE}} || exit
+    EOF
+    sudo chmod +x /tmp/pull.sh
+    sudo bash /tmp/pull.sh
 - name: "Creating the Cronjob for running the script at reboot."
   shell: |
     sudo chmod +x /root/customize.sh && sudo touch /etc/crontab && sudo crontab -l; echo "@reboot /root/customize.sh" | crontab -

--- a/builds/linux/debian/linux-debian.pkr.hcl
+++ b/builds/linux/debian/linux-debian.pkr.hcl
@@ -197,7 +197,10 @@ build {
       "--extra-vars", "BUILD_SECRET='${var.build_key}'",
       "--extra-vars", "ANSIBLE_USERNAME=${var.ansible_username}",
       "--extra-vars", "ANSIBLE_SECRET='${var.ansible_key}'",
-      "--extra-vars", "RAY_DOCKER_IMAGE=${var.common_ray_docker_image}"
+      "--extra-vars", "RAY_DOCKER_IMAGE=${var.common_ray_docker_image}",
+      "--extra-vars", "RAY_DOCKER_REPO=${var.common_ray_docker_repo}",
+      "--extra-vars", "RAY_DOCKER_USERNAME=${var.common_ray_docker_username}",
+      "--extra-vars", "RAY_DOCKER_PASSWORD=${var.common_ray_docker_password}"
     ]
   }
 

--- a/builds/linux/debian/variable.pkr.hcl
+++ b/builds/linux/debian/variable.pkr.hcl
@@ -409,3 +409,18 @@ variable "common_ray_docker_image" {
   type        = string
   description = "Default Ray docker image from official Ray docker repo."
 }
+
+variable "common_ray_docker_repo" {
+  type        = string
+  description = "Registry url  of ray docker image"
+}
+
+variable "common_ray_docker_username" {
+  type        = string
+  description = "Username to login registry of Ray docker image"
+}
+
+variable "common_ray_docker_password" {
+  type        = string
+  description = "Password to login registry of Ray docker image"
+}

--- a/builds/vsphere.pkrvars.hcl
+++ b/builds/vsphere.pkrvars.hcl
@@ -68,7 +68,6 @@ common_ray_docker_repo = ""
 common_ray_docker_username = ""
 common_ray_docker_password = ""
 
-
 // Guest Operating System Metadata
 vm_guest_os_language = "en_US"
 vm_guest_os_keyboard = "us"

--- a/builds/vsphere.pkrvars.hcl
+++ b/builds/vsphere.pkrvars.hcl
@@ -64,6 +64,10 @@ common_shutdown_timeout = "15m"
 
 // Ray docker image
 common_ray_docker_image = "rayproject/ray:latest"
+common_ray_docker_repo = ""
+common_ray_docker_username = ""
+common_ray_docker_password = ""
+
 
 // Guest Operating System Metadata
 vm_guest_os_language = "en_US"

--- a/scripts/config.hcl
+++ b/scripts/config.hcl
@@ -30,4 +30,9 @@ iso_path = "iso_files/"
 # The content library name for exporting the OVF of the Frozen VM. If the content
 # library doesn't exist, a new one will be created automatically
 common_content_library_name = "your_content_library_name"
+
+# Ray docker image, repos and credentials
 common_ray_docker_image = "rayproject/ray:2.7.0"
+common_ray_docker_repo = "ray_image_docker_repos"
+common_ray_docker_username = "username_login_docker_repos"
+common_ray_docker_password = "password_login_docker_repos"


### PR DESCRIPTION
Test the following scenarios, all passed.
# scenario 1
## Step 1
Create one frozen VM by the following command:
```
bash create-frozen-vm.sh 
```
and the following configuration:
```
frozen_vm_prefix_name   = "test-2-frozen-vm"
common_ray_docker_image = "rayproject/ray:2.7.0"
common_ray_docker_repo = "docker.io"
common_ray_docker_username = "<my-username-which-can't-tell-you>"
common_ray_docker_password = "<my-password-which-can't-tell-you>"
```
Need to login this repos, or it will report error: 
## Result of Step 1
One frozen vm with name `test-2-frozen-vm-1` is created.

![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/324064a5-e9de-4dee-a524-f0da7ee75ad9)

## Step 2
Bring up ray cluster with those frozen vms with the following command:
```
ray up vsphere.yaml -y --no-config-cache
```
and the following configuration
```
provider:
    type: vsphere
    ....
    vsphere_config:
      ...
      datacenter: x77-dc
      frozen_vm:
        name: test-2-frozen-vm-1
```
## Result of Step 2

Check the result both from vsphere page and dashboard, the ray cluster is provisioned successfully.

![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/dbc1b708-1a2a-4368-a9f5-c296752c7642)

![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/639417df-2f3f-4c56-9291-dbe92564e93f)

Chek the images on head VM, which is as expected.
```
ray@94befd06-89bf-412a-994d-3815bfa5de98:~$ docker ps
CONTAINER ID   IMAGE                  COMMAND   CREATED        STATUS        PORTS     NAMES
74ccb4314b1a   rayproject/ray:2.7.0   "bash"    17 hours ago   Up 17 hours             ray_container
```

# scenario 2
## Step 1
Create one frozen VM by the following command:
```
bash create-frozen-vm.sh 
```
and the following configuration:
```
frozen_vm_prefix_name   = "test-3-frozen-vm"
common_ray_docker_image = "harbor-repo.vmware.com/ray/rayproject-ray:2.7.0"
common_ray_docker_repo = ""
common_ray_docker_username = ""
common_ray_docker_password = ""
```
No need to login this repos in vmware network.

## Result of Step 1
One frozen vm with name `test-3-frozen-vm-1` is created.

![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/f61e6554-9517-4e92-b6e8-70ff54c638a0)

## Step 2
Bring up ray cluster with those frozen vms with the following command:
```
ray up vsphere.yaml -y --no-config-cache
```
and the following configuration
```
provider:
    type: vsphere
    ....
    vsphere_config:
      ...
      datacenter: x77-dc
      frozen_vm:
        name: test-3-frozen-vm-1
```
## Result of Step 2

Check the result both from vsphere page and dashboard, the ray cluster is provisioned successfully.
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/88b33357-368c-48e3-ab19-ee4ff69de196)
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/c0e9a348-2d98-408c-86c8-39d5a2fc0b3e)

Chek the images on head VM, which is as expected.
```
ray@c30cbb89-abeb-4b4d-bb93-ccc369c54887:~$ docker ps
CONTAINER ID   IMAGE                                             COMMAND   CREATED         STATUS         PORTS     NAMES
85a2434f9f1d   harbor-repo.vmware.com/ray/rayproject-ray:2.7.0   "bash"    4 minutes ago   Up 4 minutes             ray_container
```

