### PR TITLE
ping vmware.com once to refresh the ARP cache

### DIFF
--- a/scripts/customize.sh
+++ b/scripts/customize.sh
@@ -36,3 +36,6 @@ systemctl restart resolvconf.service
 echo "=== End of Post-Freeze ==="
 
 echo -e "\nCheck /root/network.log for details\n\n"
+
+sleep 30
+ping -c 1 vmware.com


### PR DESCRIPTION
## Introduction
We find the below issue when deploying the frozen VM from OVF,  and Ray up based on the Frozen VM immediately.
```
ssh: connect to host 10.78.113.6 port 22: Connection timed out
    SSH still not available (SSH command failed.), retrying in 5 seconds.
ssh: connect to host 10.78.113.6 port 22: Connection timed out
    SSH still not available (SSH command failed.), retrying in 5 seconds.
ssh: connect to host 10.78.113.6 port 22: Connection timed out
    SSH still not available (SSH command failed.), retrying in 5 seconds.
ssh: connect to host 10.78.113.6 port 22: Connection timed out
```

At this moment, if I login the host 10.78.113.6 and trigger an egress network traffic. Then above issue got resolved immediately.

The root cause could be the Frozen VM has registered its Mac address on the router/switch, and when it is frozen. it doesn't refresh the ARP cache. The Head node instant cloned from the Frozen VM should have either inherited the IP address of the frozen VM or the Switch Port of the frozen VM. So that the new Packets will be send to the old Mac address, which caused the issue.

## Fix

Let the Ray node created by instant clone to send out a Packet after some delay, to refresh the ARP cache proactively. 

## Test

After change, still deploy a frozen VM from OVF then do "ray up", verified that the issue is gone.