### PR TITLE
wait cloud init done before freeze the VM

### DIFF
--- a/scripts/customize.sh
+++ b/scripts/customize.sh
@@ -5,7 +5,15 @@
 set -x
 exec 2>/root/ic-customization.log
 
-echo -e "Stop networking services ...\n"
+echo -e "Wait for cloud init is done...\n"
+
+STATUS_FILE="/var/lib/cloud/instance/boot-finished"
+
+while [ ! -f "$STATUS_FILE" ]; do
+    sleep 5
+done
+
+echo -e "Stop networking services...\n"
 
 systemctl stop networking.service
 systemctl stop resolvconf.service


### PR DESCRIPTION
## Desc
The cloud init is responsible for generate the host keys, that is necessary for start the sshd service.

However, the vm usually goes into frozen before the cloud init finished. This is why the ssh host keys are missing the content. 

In this change, I change the customzi.sh script to wait for the cloud init done, then freeze the VM.

## Test

After change, verified that the frozen VM's ssh service is running after power off and power on.