### PR TITLE
support frozen vm and ray node vm to restart multiple times

### DIFF
--- a/scripts/customize.sh
+++ b/scripts/customize.sh
@@ -5,7 +5,13 @@
 set -x
 exec 2>/root/ic-customization.log
 
-echo -e "Stop networking services ...\n"
+echo -e "Wait for cloud init is done...\n"
+STATUS_FILE="/var/lib/cloud/instance/boot-finished"
+while [ ! -f "$STATUS_FILE" ]; do
+    sleep 5
+done
+
+echo -e "Stop networking services...\n"
 
 systemctl stop networking.service
 systemctl stop resolvconf.service
@@ -39,3 +45,6 @@ echo -e "\nCheck /root/network.log for details\n\n"
 
 sleep 30
 ping -c 1 vmware.com
+
+echo "Remove cronjob to make sure this script only execute once..."
+crontab -l | grep -v 'customize.sh' | crontab -


### PR DESCRIPTION
# Description
## Issue 1
When frozen VM is generated from packer builder, it is power-off status. If we power on it, the frozen VM is entering frozen status. Then we restart the frozen VM again, it will report the following error:
```
Failed to start ssh.service - OpenBSD Secure Shell server
```
And the frozen VM is without ssh service. If we provision a ray cluster with this frozen VM, it will report the following error
```
ssh: connect to host 10.78.129.249 port 22: Connection refused" error.
```
## Solution of Issue1
The cloud init is responsible for generate the host keys, that is necessary for start the sshd service.
However, the vm usually goes into frozen before the cloud init finished. This is why the ssh host keys are missing the content.
In this change, we change the customzi.sh script to wait for the cloud init done, then freeze the VM.

## Issue 2
When we provision a ray cluster, everything works fine. But if we restart any ray node VM, and the ray node VM will execute  customize.sh and enters frozen status.

## Solution of Issue2
The script customize.sh should be execute once. Once it was executed, remove it from crontab item.


# Test

## Restart the frozen VM
Create frozen VM "a-frozen-vm-1", and power on it, waiting for it entering frozen status.
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/11547283-871e-4e37-8e77-ae0c87d9b690)

Then restart it, and check its status. it still frozen.
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/93d469c3-b4fc-43e8-ae49-c98698a6e940)

## Restart ray node VM
Provision ray cluster with this frozen VM "a-frozen-vm-1", and check the result both from vsphere page and dashboard, the ray cluster is provisioned successfully.
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/013e1053-03af-4d25-9872-77721bf0fa53)
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/cd260258-37c5-461d-86ef-c9b0e96bdbe5)

Restart the ray node VM, and check its status, which is good and doesn't enter frozen status as expect.
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/2c36f377-cc10-4e3f-b0ff-5c3c81f0b586)




