### PR TITLE
Support configuring the dependeicies of GPU

### DIFF
--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -58,3 +58,30 @@
 - name: "Creating the Cronjob for running the script at reboot."
   shell: |
     sudo chmod +x /root/customize.sh && sudo touch /etc/crontab && sudo crontab -l; echo "@reboot /root/customize.sh" | crontab -
+# GPU related optional operations
+# url: "https://developer.download.nvidia.com/compute/cuda/12.2.1/local_installers/cuda_12.2.1_535.86.10_linux.run"\
+- name: "Block the default nouveau driver."
+  shell: |
+    echo -e "blacklist nouveau\noptions nouveau modeset=0" | sudo tee /etc/modprobe.d/blacklist-nouveau.conf
+    sudo update-initramfs -u
+  when: GPU_DRIVER_DOWNLOAD_URL != ""
+- name: "Install more linux dependencies."
+  shell: |
+    sudo apt install -y  binutils cpp gcc make psmisc linux-headers-$(uname -r) libmspack-dev build-essential libglvnd-dev pkg-config
+  when: GPU_DRIVER_DOWNLOAD_URL != ""
+- name: "Download and install the GPU driver."
+  shell: |
+    sudo wget {{GPU_DRIVER_DOWNLOAD_URL}} -q
+    sudo bash $(basename {{GPU_DRIVER_DOWNLOAD_URL}}) -s
+  when: GPU_DRIVER_DOWNLOAD_URL != ""
+- name: "Download and install the Nvidia container toolkit."
+  shell: |
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+    && curl -s -L https://nvidia.github.io/libnvidia-container/debian10/libnvidia-container.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    sudo apt-get update
+    sudo apt-get install -y nvidia-container-toolkit
+    sudo nvidia-ctk runtime configure --runtime=docker
+    sudo systemctl restart docker
+  when: GPU_DRIVER_DOWNLOAD_URL != ""

--- a/builds/linux/debian/linux-debian.pkr.hcl
+++ b/builds/linux/debian/linux-debian.pkr.hcl
@@ -199,7 +199,8 @@ build {
       "--extra-vars", "RAY_DOCKER_IMAGE=${var.common_ray_docker_image}",
       "--extra-vars", "RAY_DOCKER_REPO=${var.common_ray_docker_repo}",
       "--extra-vars", "RAY_DOCKER_USERNAME=${var.common_ray_docker_username}",
-      "--extra-vars", "RAY_DOCKER_PASSWORD=${var.common_ray_docker_password}"
+      "--extra-vars", "RAY_DOCKER_PASSWORD=${var.common_ray_docker_password}",
+      "--extra-vars", "GPU_DRIVER_DOWNLOAD_URL=${var.gpu_driver_download_url}"
     ]
   }
 

--- a/builds/linux/debian/variable.pkr.hcl
+++ b/builds/linux/debian/variable.pkr.hcl
@@ -418,3 +418,9 @@ variable "common_ray_docker_password" {
   type        = string
   description = "Password to login registry of Ray docker image"
 }
+
+variable "gpu_driver_download_url" {
+  type = string
+  description = "The URL for downloading the Driver for the GPU"
+  default = ""
+}

--- a/builds/vsphere.pkrvars.hcl
+++ b/builds/vsphere.pkrvars.hcl
@@ -108,3 +108,6 @@ communicator_timeout = "30m"
 
 // Instant Clone Customization Engine setup path
 instant_clone_customization_engine_path = "/dependencies/vmware-gosc_12.1.0.25580-20029049_amd64.deb"
+
+// The url for the GPU driver
+gpu_driver_download_url = ""

--- a/scripts/overwrite_vars.py
+++ b/scripts/overwrite_vars.py
@@ -28,5 +28,4 @@ with open(DEFAULT_CONFIG_PATH, "r") as default_config:
 with open(TARGET_FILE_PATH, "w") as target_file:
     hcl_content = hcl.dumps(target_config, indent=4)
     target_file.write(hcl_content)
-    print(f"overwritten the default variables with {source_config}")
     print(f"saved the generated json file to {TARGET_FILE_PATH}")


### PR DESCRIPTION
## Description
This change add the functionality for building the GPU driver optionally into the frozen VM. The driver is mandatory for the Ray nodes to detect the GPU.
Added one variable, if set, then 4 more steps will run during building the frozen VM:
1. Blocker the nouveau driver on linux which could bring issues.
2. Install more dependencies the GPU driver needed.
3. Download and install the GPU driver, the url we use for the test is "https://us.download.nvidia.com/tesla/535.104.12/NVIDIA-Linux-x86_64-535.104.12.run"
4. Install the container toolkit.

Notice: The container toolkit is for debian 10, and is hard coded, this is expected, because there is no officially debian 12's container toolkit, and we have verified that Debian 10's toolkit works.

## Test
Verified that we can build a frozen VM successfully, but the time is 35 min, this is expected because we have more things to  download and install.

Verified that running "nvidia-smi" in the Ray nodes cloned from that frozen VM have the capability to print the GPU msg.