### PR TITLE
Add permissions to the volumes

### DIFF
--- a/create-frozen-vm.sh
+++ b/create-frozen-vm.sh
@@ -83,6 +83,6 @@ if [ "$enable_frozenvm_each_host" = true ]; then
 fi
 # Launch packer build
 docker run --tty --rm --name packer-builder -v \
-"$(pwd)":/home/packer ${packer_builder_image} \
+"$(pwd)":/home/packer ${packer_builder_image}:rw \
 bash -c "$command_in_container"
 echo "Packer build finished."


### PR DESCRIPTION
## Description
This can help eliminate issues like this:
```
Traceback (most recent call last):
  File "/home/packer/scripts/overwrite_vars.py", line 28, in <module>
    with open(TARGET_FILE_PATH, "w") as target_file:
PermissionError: [Errno 13] Permission denied: '/home/packer/config/vsphere.pkr.json'
```

The root cause is the user ray in the container has no permission to write to a file in the volume mounted from a host. On which the user is someone else.

## Test

After fix the permission issue is resolved.