### PR TITLE
Enable Git LFS for large files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.tgz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.doc filter=lfs diff=lfs merge=lfs -text
+*.gpg filter=lfs diff=lfs merge=lfs -text
+*.docx filter=lfs diff=lfs merge=lfs -text
+*.plist filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text
+*.pptx filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.m4a filter=lfs diff=lfs merge=lfs -text
+packer-plugin-vsphere_*_linux_amd filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Github was issuing the warning:

```
remote: warning: See https://gh.io/lfs for more information.
remote: warning: File e6ac23fbdd7b4f79a15d463c3dd54724bf363c90 is 56.99 MB; this is larger than GitHub's recommended maximum file size of 50.00 MB
remote: warning: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
```

The `e6ac23fbdd7b4f79a15d463c3dd54724bf363c90` SHA refers to the file `plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.2.1_x5.0_linux_amd64`, which is a binary file. I added a `.gitattributes` file that enables LFS storage for this file, as well as other common binary files.