### PR TITLE
Disable the secure boot by default

### DIFF
--- a/builds/linux/debian/variable.pkr.hcl
+++ b/builds/linux/debian/variable.pkr.hcl
@@ -114,7 +114,7 @@ variable "vm_guest_os_type" {
 variable "vm_firmware" {
   type        = string
   description = "The virtual machine firmware. (e.g. 'efi-secure'. 'efi', or 'bios')"
-  default     = "efi-secure"
+  default     = "efi"
 }
 
 variable "vm_cdrom_type" {

--- a/builds/vsphere.pkrvars.hcl
+++ b/builds/vsphere.pkrvars.hcl
@@ -80,7 +80,7 @@ vm_guest_os_version  = "12.0"
 vm_guest_os_type = "other5xLinux64Guest"
 
 // Virtual Machine Hardware Settings
-vm_firmware              = "efi-secure"
+vm_firmware              = "efi"
 vm_cdrom_type            = "sata"
 vm_cpu_count             = 1
 vm_cpu_cores             = 1

--- a/scripts/customize.sh
+++ b/scripts/customize.sh
@@ -22,6 +22,9 @@ vmware-rpctool "instantclone.freeze"
 
 echo -e "\n=== Start Post-Freeze ==="
 
+echo "Remove cronjob to make sure this script only execute once..."
+crontab -l | grep -v 'customize.sh' | crontab -
+
 for NETDEV in /sys/class/net/e*
 do
         DEVICE_LABEL=$(basename "$(readlink -f "$NETDEV/device")")
@@ -45,6 +48,3 @@ echo -e "\nCheck /root/network.log for details\n\n"
 
 sleep 30
 ping -c 1 vmware.com
-
-echo "Remove cronjob to make sure this script only execute once..."
-crontab -l | grep -v 'customize.sh' | crontab -


### PR DESCRIPTION
## Description
I would like to set the default value for this boot option to "efi".

This will quickly unblock our test for GPU.

In specific, when security boot is enabled, the VM's Nvidia Driver will not be usable after VM reboot. This is because the change to the kernel is treated as insecure.

In this change I turn off the secure boot option for default.

## Test
After doing this, verified that a frozen VM can be built. 

For a Ray node create from this frozen VM, power it off, bind the GPU by PCI passthru then power it on.
Verified that the GPU info can be printed, which means the Nvidia driver is available:

```
ray@f1db0654-ae51-47b2-949e-55acde3d4368:~$ nvidia-smi
Tue Oct 17 06:20:08 2023
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.104.12             Driver Version: 535.104.12   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla V100-PCIE-16GB           Off | 00000000:03:00.0 Off |                    0 |
| N/A   25C    P0              35W / 250W |      0MiB / 16384MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```