### PR TITLE
Fix ERROR: 'failed to remove vm-packer-for-ray/scripts/__pycache__/py…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,4 @@ ENV PATH /home/ray/.local/bin:/home/ray/.local/pipx/shared/bin:$PATH
 RUN pip install pyhcl==0.4.5
 RUN pip install requests
 RUN pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0
+ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
…vmomi_client.cpython-310.pyc: Permission denied'

> If this is set to a non-empty string, Python won’t try to write .pyc files on the import of source modules.
> https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE

Signed-off-by: Chenlong Ma <chenlongm@vmware.com>