### PR TITLE
Add one more step to enable the auto setting online for CPU and memory

### DIFF
--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -58,6 +58,11 @@
 - name: "Creating the Cronjob for running the script at reboot."
   shell: |
     sudo chmod +x /root/customize.sh && sudo touch /etc/crontab && sudo crontab -l; echo "@reboot /root/customize.sh" | crontab -
+- name: "Enable the auto setting online for the hot-added CPU and memory"
+  shell: |
+    echo 'ACTION=="add", SUBSYSTEM=="cpu", ATTR{online}=="0", ATTR{online}="1"' | sudo tee /etc/udev/rules.d/94-hotplug-cpu-mem.rules
+    echo 'ACTION=="add", SUBSYSTEM=="memory", ATTR{state}=="offline", ATTR{state}="online"' | sudo tee -a /etc/udev/rules.d/94-hotplug-cpu-mem.rules
+
 # GPU related optional operations
 # url: "https://developer.download.nvidia.com/compute/cuda/12.2.1/local_installers/cuda_12.2.1_535.86.10_linux.run"\
 - name: "Block the default nouveau driver."


### PR DESCRIPTION
## Description

When using cpu and memory hot-add feature on vSphere, the VM on vSphere shows that it has 4 CPU and 8 GB memory. However, in the VM's guest OS, I find that when I run free -m, the memory is still 4GB, and when I run nproc, it shows 1.

## Test
Verified that the hot-add works, in this case I added the GPU to 8 cores and the memory to 8 gig. Before the fix the values will equal to the frozen VM's values.

![Screenshot 2023-10-23 at 15 12 52](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/15973672/84d5081f-52b8-45fe-8002-e14e5121d5d5)
