### PR TITLE
Remove the cronjob before freeze the VM

### DIFF
--- a/scripts/customize.sh
+++ b/scripts/customize.sh
@@ -16,14 +16,14 @@ echo -e "Stop networking services...\n"
 systemctl stop networking.service
 systemctl stop resolvconf.service
 
+echo "Remove cronjob to make sure this script only execute once..."
+crontab -l | grep -v 'customize.sh' | crontab -
+
 echo -e "Freezing ...\n"
 
 vmware-rpctool "instantclone.freeze"
 
 echo -e "\n=== Start Post-Freeze ==="
-
-echo "Remove cronjob to make sure this script only execute once..."
-crontab -l | grep -v 'customize.sh' | crontab -
 
 for NETDEV in /sys/class/net/e*
 do


### PR DESCRIPTION
If we remove the cronjob during the unfreeze stage, then when we power off the VM to bind the GPU, it could happen that the cronjob hasn't been deleted yet. Which will cause the worker node turns into a frozen VM.