### PR TITLE
Code improve: Change mount to copy vm-packer-script to container

### DIFF
--- a/create-frozen-vm.sh
+++ b/create-frozen-vm.sh
@@ -104,20 +104,12 @@ fi
 
 command_in_container="${command_in_container} --os ${os}"
 
-chmod -R o+w config
-chmod -R o+w manifests
-chmod -R o+w scripts
-chmod -R o+w plugins
 # Launch packer build
 container_name=${repository}
+docker create --tty --name ${container_name} "${packer_builder_image}"
+docker cp "$(pwd)" ${container_name}:/home/packer
+docker start ${container_name}
+docker exec --tty ${container_name} bash -c "$command_in_container"
 
-docker run --tty --rm --name ${container_name} -v \
-"$(pwd)":/home/packer:rw "${packer_builder_image}" \
-bash -c "$command_in_container"
-
-
-chmod -R o-w config
-chmod -R o-w manifests
-chmod -R o-w scripts
-chmod -R o-w plugins
 echo "Packer build finished."
+docker rm -f ${container_name}


### PR DESCRIPTION
# Decription 


Currently, when building frozen VM, it mounts vm-packer-script from the directory of host machine to container，which caused potential permission when the user between host machine and container is different.

Change it to copy vm-packer-script from the directory of host machine to container, which should fix this issue.


# Test
Build frozen VM successfully.
Bring up ray cluster with this frozen VM successfully.

![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/869cbd3d-a28c-4dbd-8cb7-c68fb7628a0f)

![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/c938bcab-e3c4-4fc2-977f-be240adfc9d7)

 
