### PR TITLE
Implement a mechanism to define docker images to pull

### DIFF
--- a/ansible/roles/configure/tasks/debian.yml
+++ b/ansible/roles/configure/tasks/debian.yml
@@ -44,7 +44,7 @@
     sudo /usr/bin/dpkg -i --force-all /tmp/vmware-gosc_12.1.0.25580-20029049_amd64.deb >> ./dpkg.log 2>&1
 - name: "Pulling latest docker image from {{RAY_DOCKER_IMAGE}}"
   shell: |
-    sudo tee /tmp/pull.sh << EOF
+    sudo tee /tmp/pull-ray-image.sh << EOF
     #!/bin/bash
     sudo systemctl daemon-reload  || exit
     sudo systemctl restart docker || exit
@@ -53,8 +53,23 @@
     fi
     sudo docker pull {{RAY_DOCKER_IMAGE}} || exit
     EOF
-    sudo chmod +x /tmp/pull.sh
-    sudo bash /tmp/pull.sh
+    sudo chmod +x /tmp/pull-ray-image.sh
+    sudo bash /tmp/pull-ray-image.sh
+- name: "Pulling custom docker image from {{CUSTOM_DOCKER_IMAGES}}"
+  shell: |
+    sudo tee /tmp/pull-custom-image.sh << EOF
+    #!/bin/bash
+    IFS=","
+    CUSTOM_DOCKER_IMAGES="{{CUSTOM_DOCKER_IMAGES}}"
+    CUSTOM_DOCKER_IMAGE_ARR=(\$CUSTOM_DOCKER_IMAGES)
+    for CUSTOM_DOCKER_IMAGE in \${CUSTOM_DOCKER_IMAGE_ARR[@]}
+    do
+      sudo docker pull \${CUSTOM_DOCKER_IMAGE} || exit
+    done
+    EOF
+    sudo chmod +x /tmp/pull-custom-image.sh
+    sudo bash /tmp/pull-custom-image.sh
+  when: CUSTOM_DOCKER_IMAGES != ""
 - name: "Creating the Cronjob for running the script at reboot."
   shell: |
     sudo chmod +x /root/customize.sh && sudo touch /etc/crontab && sudo crontab -l; echo "@reboot /root/customize.sh" | crontab -

--- a/builds/linux/debian/linux-debian.pkr.hcl
+++ b/builds/linux/debian/linux-debian.pkr.hcl
@@ -199,6 +199,7 @@ build {
       "--extra-vars", "ANSIBLE_USERNAME=${var.ansible_username}",
       "--extra-vars", "ANSIBLE_SECRET='${var.ansible_key}'",
       "--extra-vars", "RAY_DOCKER_IMAGE=${var.common_ray_docker_image}",
+      "--extra-vars", "CUSTOM_DOCKER_IMAGES=${var.common_custom_docker_images}",
       "--extra-vars", "RAY_DOCKER_REPO=${var.common_ray_docker_repo}",
       "--extra-vars", "RAY_DOCKER_USERNAME=${var.common_ray_docker_username}",
       "--extra-vars", "RAY_DOCKER_PASSWORD=${var.common_ray_docker_password}",

--- a/builds/linux/debian/variable.pkr.hcl
+++ b/builds/linux/debian/variable.pkr.hcl
@@ -401,8 +401,6 @@ variable "common_custom_docker_images" {
   description = "Any additional docker images you want to pull"
 }
 
-
-
 variable "common_ray_docker_repo" {
   type        = string
   description = "Registry url  of ray docker image"

--- a/builds/linux/debian/variable.pkr.hcl
+++ b/builds/linux/debian/variable.pkr.hcl
@@ -394,6 +394,15 @@ variable "common_ray_docker_image" {
   description = "Default Ray docker image from official Ray docker repo."
 }
 
+// Custom docker images
+
+variable "common_custom_docker_images" {
+  type        = string
+  description = "Any additional docker images you want to pull"
+}
+
+
+
 variable "common_ray_docker_repo" {
   type        = string
   description = "Registry url  of ray docker image"

--- a/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/linux-ubuntu.pkr.hcl
@@ -206,6 +206,7 @@ build {
       "--extra-vars", "ANSIBLE_USERNAME=${var.ansible_username}",
       "--extra-vars", "ANSIBLE_SECRET='${var.ansible_key}'",
       "--extra-vars", "RAY_DOCKER_IMAGE=${var.common_ray_docker_image}",
+      "--extra-vars", "CUSTOM_DOCKER_IMAGES=${var.common_custom_docker_images}",
       "--extra-vars", "RAY_DOCKER_REPO=${var.common_ray_docker_repo}",
       "--extra-vars", "RAY_DOCKER_USERNAME=${var.common_ray_docker_username}",
       "--extra-vars", "RAY_DOCKER_PASSWORD=${var.common_ray_docker_password}",

--- a/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/20-04-lts/variables.pkr.hcl
@@ -408,6 +408,14 @@ variable "common_ray_docker_image" {
   description = "Default Ray docker image from official Ray docker repo."
 }
 
+// Custom docker images
+
+variable "common_custom_docker_images" {
+  type        = string
+  description = "Any additional docker images you want to pull"
+}
+
+
 variable "common_ray_docker_repo" {
   type        = string
   description = "Registry url  of ray docker image"

--- a/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/linux-ubuntu.pkr.hcl
@@ -206,6 +206,7 @@ build {
       "--extra-vars", "ANSIBLE_USERNAME=${var.ansible_username}",
       "--extra-vars", "ANSIBLE_SECRET='${var.ansible_key}'",
       "--extra-vars", "RAY_DOCKER_IMAGE=${var.common_ray_docker_image}",
+      "--extra-vars", "CUSTOM_DOCKER_IMAGES=${var.common_custom_docker_images}",
       "--extra-vars", "RAY_DOCKER_REPO=${var.common_ray_docker_repo}",
       "--extra-vars", "RAY_DOCKER_USERNAME=${var.common_ray_docker_username}",
       "--extra-vars", "RAY_DOCKER_PASSWORD=${var.common_ray_docker_password}",

--- a/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
+++ b/builds/linux/ubuntu/22-04-lts/variables.pkr.hcl
@@ -408,6 +408,14 @@ variable "common_ray_docker_image" {
   description = "Default Ray docker image from official Ray docker repo."
 }
 
+// Custom docker images
+
+variable "common_custom_docker_images" {
+  type        = string
+  description = "Any additional docker images you want to pull"
+}
+
+
 variable "common_ray_docker_repo" {
   type        = string
   description = "Registry url  of ray docker image"

--- a/builds/vsphere.pkrvars.hcl
+++ b/builds/vsphere.pkrvars.hcl
@@ -64,6 +64,7 @@ common_shutdown_timeout = "15m"
 
 // Ray docker image
 common_ray_docker_image = "rayproject/ray:latest"
+common_custom_docker_images = ""
 common_ray_docker_repo = ""
 common_ray_docker_username = ""
 common_ray_docker_password = ""


### PR DESCRIPTION
# Decription

Implement a mechanism to define docker images to pull. This is defined in configuration file "scripts/config.hcl", which is a list of images separated by comma 
`
common_custom_docker_images = "<image1>,<image2>"
`
For example, if you want pull image "hello-world:latest" and image "alpine:latest" in this OVF. You can define it as followed:

`
common_custom_docker_images = "hello-world:latest,alpine:latest"
`

# Test 
Use the following configuration:
`
common_custom_docker_images = "hello-world:latest,alpine:latest"
`
A frozen VM are generated successfully.
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/adbda3fe-2a1e-4364-b1db-07336821f77e)


A ray cluster are provisioned successfully with this frozen VM .
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/48622fab-98d4-4027-b339-e29a4cddb824)
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/037c94bd-a3a0-4739-ae44-39a7a998e2e7)

Check the head node, which is containing docker images as expected:
![image](https://github.com/vmware-ai-labs/vm-packer-for-ray/assets/85480625/de4c70bc-fe36-4e12-88ca-75fc973d7abd)



